### PR TITLE
test: initial entries should have at least single .entry element

### DIFF
--- a/jasmine/spec/feedreader.js
+++ b/jasmine/spec/feedreader.js
@@ -90,14 +90,20 @@ $(function() {
     });
 
 
-    /* TODO: Write a new test suite named "Initial Entries" */
-
-        /* TODO: Write a test that ensures when the loadFeed
+    describe('Initial Entries', function(){
+        beforeEach(function(done){
+          loadFeed(0, done);
+        });
+        /* A test that ensures when the loadFeed
          * function is called and completes its work, there is at least
          * a single .entry element within the .feed container.
          * Remember, loadFeed() is asynchronous so this test will require
          * the use of Jasmine's beforeEach and asynchronous done() function.
          */
+         it('should have at least a single .entry element ',function(){
+           expect($('.feed .entry')[0]).toBeTruthy();
+         });
+   });
 
     /* TODO: Write a new test suite named "New Feed Selection"
 


### PR DESCRIPTION
This test ensures that when the asynchrnous loadFeed function is called and completes
its work, there is at least a single .entry element within the .feed container.