### PR TITLE
refactor: getAttribute is replaced by classList in the menu test suite

### DIFF
--- a/jasmine/spec/feedreader.js
+++ b/jasmine/spec/feedreader.js
@@ -72,7 +72,7 @@ $(function() {
        * hiding/showing of the menu element.
        */
        it('is hidden by default', function(){
-          expect($body.getAttribute('class')).toContain('menu-hidden');
+          expect($body.classList).toContain('menu-hidden');
         });
 
      /* A test that ensures the menu changes
@@ -82,10 +82,10 @@ $(function() {
       */
       it('should change visibility onclick', function(){
         $menuIcon.trigger('click');
-        expect($body.getAttribute('class')).not.toContain('menu-hidden');
+        expect($body.classList).not.toContain('menu-hidden');
 
         $menuIcon.trigger('click');
-        expect($body.getAttribute('class')).toContain('menu-hidden');
+        expect($body.classList).toContain('menu-hidden');
       });
     });
 


### PR DESCRIPTION
getAttribute returns a string of classes, and using the toContain on
string makes expectation not reliable. If in future anything is added
in the end of class name, it can cause the functionality to break without
failing the test. So in the current implementation classList is used instead
of getAttribute. classList returns an array of classes on an element.
Using toContain on an array would make the test would fail even if
something is added at the end of a class name.